### PR TITLE
[CPLAT-6712] refactor principals block to allow only aws key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,14 +19,15 @@ data "aws_iam_policy_document" "trustrel" {
     }
   }
 
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    dynamic "principals" {
-      for_each = { for k, v in var.principals : k => v if contains(["federated"], k) }
-      content {
-        type        = lower(principals.key) == "federated" ? "Federated" : title(principals.key)
-        identifiers = principals.value
+
+  dynamic "statement" {
+    for_each = { for k, v in var.principals : k => v if contains(["federated"], k) }
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRoleWithWebIdentity"]
+      principals {
+        type        = title(statement.key)
+        identifiers = statement.value
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -2,11 +2,6 @@
 
 variable "principals" {
   description = "The map of trust relationship to allow them to assume roles in this role"
-  default = {
-    aws       = ["336686831133"]
-    service   = [""]
-    federated = [""]
-  }
 }
 
 variable "policy_arn" {


### PR DESCRIPTION
To correct this error:
```hcl
│ Error: updating IAM Role (ci-ops) assume role policy: operation error IAM: UpdateAssumeRolePolicy, https response error StatusCode: 400, RequestID: ef327556-56ce-41cb-9b06-f0d80cca3902, MalformedPolicyDocument: Missing required field Principal
│ 
│   with module.ci-role.aws_iam_role.role,
│   on .terraform/modules/ci-role/main.tf line 3, in resource "aws_iam_role" "role":
│    3: resource "aws_iam_role" "role" {
│ 
```